### PR TITLE
projects: docker: first script

### DIFF
--- a/projects/docker.sh
+++ b/projects/docker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+docker2aci quay.io/alban/dind:dockerinrocket
+actool patch-manifest --replace --capability=CAP_NET_ADMIN alban-dind-dockerinrocket.aci
+
+## Example how to use it
+########################
+
+
+## Copy the aci
+# scp alban-dind-dockerinrocker.aci core-01:/var/tmp/
+
+## On the host
+
+# DOCKER_DAEMON_ARGS='-D -s=overlay' /var/tmp/rkt --insecure-skip-verify run -inherit-env --interactive  /var/tmp/alban-dind-dockerinrocket.aci
+
+## In Rocket:
+
+## Populate /etc/resolv.conf or fix https://github.com/coreos/rocket/issues/660
+# echo nameserver 10.0.2.3 > /etc/resolv.conf
+
+# docker run --rm busybox echo Yes this is a Docker container inside Rocket
+# docker run --rm -t -i busybox
+
+
+


### PR DESCRIPTION
I am not sure how this build-repository will work.

Should it contain scripts that will be used to automatize continuous integration, or scripts used as documentation?

In this PR, I gave an example how to use the aci produced to start Docker inside Rocket.

It needs the last version of Rocket with https://github.com/coreos/rocket/pull/653 and actool with  https://github.com/appc/spec/pull/258

/cc @philips
