### PR TITLE
Add more details about Docker, Flannel, etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
 # build-repository
 
 Repository of tools to build ACIs for various projects.
+
+## Status of each project
+
+### Docker
+
+build-repository has [projects/docker.sh](projects/docker.sh) to build an ACI. This uses [quay.io/alban/dind:dockerinrocket](https://quay.io/repository/alban/dind?tag=dockerinrocket), based on the [Docker-in-Docker](https://github.com/jpetazzo/dind/) repository.
+
+```
+$ cd projects && ./docker.sh
+```
+
+The ACI can be copied on a CoreOS computer:
+
+```
+$ scp alban-dind-dockerinrocker.aci core-01:/var/tmp/
+```
+
+Then, it can be started:
+
+```
+root@core-01:~# DOCKER_DAEMON_ARGS='-D -s=overlay' /var/tmp/rkt --insecure-skip-verify run -inherit-env --interactive  /var/tmp/alban-dind-dockerinrocket.aci
+```
+
+Once in the rkt shell, fix `/etc/resolv.conf` (see [rkt bug 660](https://github.com/coreos/rkt/issues/660)) and start Docker containers inside rkt:
+
+```
+# docker run --rm busybox echo Yes this is a Docker container inside rkt
+# docker run --rm -t -i busybox
+```
+
+### etcd
+
+etcd has [scripts/build-aci](https://github.com/coreos/etcd/blob/master/scripts/build-aci) to build an ACI:
+
+```
+$ scripts/build-aci VERSION
+```
+
+### Flannel
+
+Flannel has [dist/build-aci.sh](https://github.com/coreos/flannel/blob/master/dist/build-aci.sh) to build an ACI:
+
+```
+$ cd dist && ./build-aci.sh TAG
+```

--- a/projects/docker.sh
+++ b/projects/docker.sh
@@ -3,24 +3,3 @@
 docker2aci quay.io/alban/dind:dockerinrocket
 actool patch-manifest --replace --capability=CAP_NET_ADMIN alban-dind-dockerinrocket.aci
 
-## Example how to use it
-########################
-
-
-## Copy the aci
-# scp alban-dind-dockerinrocker.aci core-01:/var/tmp/
-
-## On the host
-
-# DOCKER_DAEMON_ARGS='-D -s=overlay' /var/tmp/rkt --insecure-skip-verify run -inherit-env --interactive  /var/tmp/alban-dind-dockerinrocket.aci
-
-## In Rocket:
-
-## Populate /etc/resolv.conf or fix https://github.com/coreos/rocket/issues/660
-# echo nameserver 10.0.2.3 > /etc/resolv.conf
-
-# docker run --rm busybox echo Yes this is a Docker container inside Rocket
-# docker run --rm -t -i busybox
-
-
-


### PR DESCRIPTION
build-repository does not need to have scripts for Flannel and etcd because they are in the upstream projects. I am adding a link to them with examples how to use them.

I am adding more details about the Docker script as well and where the dind image comes from, as requested in https://github.com/coreos/rkt/issues/638
