### PR TITLE
Create jetty9 image, fix entrypoint for java7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.build/
+image.aci.asc
+

--- a/bin/packages2aci
+++ b/bin/packages2aci
@@ -28,7 +28,8 @@ mkdir -p ${BUILD}/packages/
 
 # start from an empty build directory every time
 rm -rf ${BUILD}/layout
-mkdir -p ${BUILD}/layout/rootfs/
+ROOTFS=${BUILD}/layout/rootfs/
+mkdir -p ${ROOTFS}
 
 # download packages specified in packages
 for p in `cat ${SRCDIR}/packages`; do
@@ -39,25 +40,34 @@ for p in `cat ${SRCDIR}/packages`; do
 done
 
 # extract the packages into the rootfs dir
+shopt -s nullglob
 for d in ${BUILD}/packages/*.deb; do
   echo "Extracting $d"
-  dpkg-deb -x ${d} ${BUILD}/layout/rootfs/
+  dpkg-deb -x ${d} ${ROOTFS}
 done
 
 # copy the ACI manifest file
 cp ${SRCDIR}/manifest ${BUILD}/layout/
 
+# Copy a rootfs/ directory, if present in src
+if [[ -d ${SRCDIR}/rootfs/ ]]; then
+  # TODO: Nicer syntax?
+  cp -av ${SRCDIR}/rootfs/ ${ROOTFS}/../
+fi
+
 # call user postbuild script
 if [[ -x ${SRCDIR}/postbuild ]]; then
-  pushd ${BUILD}/layout/rootfs
-  ${SRCDIR}/postbuild ${BUILD}/layout/rootfs
+  pushd ${ROOTFS}
+  ${SRCDIR}/postbuild ${ROOTFS} ${SRCDIR}
   popd
 fi
 
 # build the ACI
 actool build --overwrite ${BUILD}/layout/ ${OUTPUT}
+# Remove the signature - it will now be invalid
+rm -f ${OUTPUT}.asc
 
 # great success
 echo "Your image is now available at ${OUTPUT}"
-echo "Test with: sudo rkt --insecure-skip-verify=true run ${OUTPUT}"
+echo "Test with: sudo rkt --insecure-skip-verify run ${OUTPUT}"
  

--- a/java7/packages
+++ b/java7/packages
@@ -35,3 +35,6 @@ openjdk-7-jre
 openjdk-7-jre-headless
 tzdata-java
 zlib1g
+bash
+libncurses5
+libtinfo5

--- a/java7/postbuild
+++ b/java7/postbuild
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
 ROOTFS=${1}
-cd ${ROOTFS}
+SRCDIR=${2}
 
 # symlink java
+cd ${ROOTFS}
 ln -s usr/lib/jvm/java-7-openjdk-amd64/bin/java java
+

--- a/java7/rootfs/run
+++ b/java7/rootfs/run
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+MAIN_CLASS=$1
+WORKDIR=/app
+MAIN_JAR=/app/app.jar
+
+JAVA_ARGS=""
+CP=""
+if [[ -n "${MAIN_CLASS}" ]]; then
+	shift
+	CP=${MAIN_JAR}
+	CP=${CP}:"/app/lib/*"
+	JAVA_ARGS="${JAVA_ARGS} ${MAIN_CLASS}"
+else
+	CP="/app/lib/*"
+	JAVA_ARGS="${JAVA_ARGS} -jar ${MAIN_JAR}"
+fi
+
+cd ${WORKDIR}
+/java -cp "${CP}" ${JAVA_ARGS} $@

--- a/jetty9/.gitignore
+++ b/jetty9/.gitignore
@@ -1,0 +1,4 @@
+.build/
+image.aci
+downloads/
+

--- a/jetty9/manifest
+++ b/jetty9/manifest
@@ -1,11 +1,11 @@
 {
   "acVersion": "0.5.1",
   "acKind": "ImageManifest",
-  "name": "aci.justinsb.com/java7",
+  "name": "aci.justinsb.com/jetty9",
   "labels": [
     {
       "name": "version",
-      "value": "7.75.0"
+      "value": "9.2.10.0"
     },
     {
       "name": "arch",
@@ -20,5 +20,8 @@
     "exec": [ "/run" ],
     "user": "0",
     "group": "0"
-  }
+  },
+  "dependencies": [
+    {"app":"aci.justinsb.com/java7"}
+  ]
 }

--- a/jetty9/packages
+++ b/jetty9/packages
@@ -1,0 +1,3 @@
+libselinux1
+libffi6
+libpcre3

--- a/jetty9/postbuild
+++ b/jetty9/postbuild
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+ROOTFS=${1}
+SRCDIR=${2}
+
+mkdir -p ${SRCDIR}/downloads
+pushd ${SRCDIR}/downloads
+wget -N "http://download.eclipse.org/jetty/stable-9/dist/jetty-distribution-9.2.10.v20150310.tar.gz"
+popd
+
+cd ${ROOTFS}
+mkdir -p jetty
+tar -x -z --strip-components=1 -C jetty -f ${SRCDIR}/downloads/jetty-distribution-9.2.10.v20150310.tar.gz
+
+pushd jetty/webapps
+ln -s ../../app/root.war
+popd

--- a/jetty9/rootfs/run
+++ b/jetty9/rootfs/run
@@ -1,0 +1,4 @@
+#!/bin/dash
+
+cd /jetty
+/java -jar start.jar


### PR DESCRIPTION
The idea is that both will have a known-entrypoint of /run

App code (jars or wars) will go into /app
